### PR TITLE
feat(cmd): add command line params support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,16 @@ The program is designed to be executed during the initrd stage in order to simul
 
 The `vsock_guest_exec` accepts commands composed of up to 2048 bytes at a time and automatically terminates after the command ends. Before running, please ensure that the host is listening to the corresponding socket file.
 
+EXAMPLES:
+
+```shell
+$ ./vsock_guest_exec 1:2049 # cid is 2, vsock port is 2049
+$ ./vsock_guest_exec -1: # cid set to -1 (VMADDR_CID_ANY), vsock port is
+default(1024)
+$ ./vsock_guest_exec :1025 # vsock port set to 1025, cid is default(2)
+
+# Invalid Params
+$ ./vsock_guest_exec foo:bar # cid is default(2), vsock port is default(1024)
+```
+
 [ignition]: https://coreos.github.io/ignition/

--- a/main.c
+++ b/main.c
@@ -10,10 +10,46 @@
 
 #define MAX_COMMAND_LENGTH 2048
 
-int main() {
-    int cid, sockfd;
+void setCID(char params[], int *cid) {
+    if (strlen(params) > 0) {
+        int _cid = atoi(params);
+        if (_cid == VMADDR_CID_ANY || _cid == VMADDR_CID_HYPERVISOR || 
+            _cid == VMADDR_CID_LOCAL || _cid == VMADDR_CID_HOST) {
+            *cid = _cid;
+        }
+    }
+}
+
+void setPort(char params[], int *port) {
+    if (strlen(params) > 0) {
+        int _port = atoi(params);
+        if (_port >= 0 && _port <= 65535) {
+            *port = _port;
+        }
+    }
+}
+
+int main(int argc, char *argv[]) {
+    int cid = VMADDR_CID_HOST;
+    int vsockPort = 1024;
+    int sockfd;
     struct sockaddr_vm sa_vm;
     char command[MAX_COMMAND_LENGTH];
+
+    if (argc > 1) {
+        char *param = argv[1];
+        char *delim = strchr(param, ':');
+        if (delim != NULL) {
+            *delim = '\0';
+            char *cidString = param;
+            char *portString = delim + 1;
+
+            setCID(cidString, &cid);
+            setPort(portString, &vsockPort);
+        } else {
+            setCID(param, &cid);
+        }
+    }
 
     sockfd = socket(AF_VSOCK, SOCK_STREAM, 0);
     if (sockfd < 0) {
@@ -23,8 +59,8 @@ int main() {
 
     memset(&sa_vm, 0, sizeof(struct sockaddr_vm));
     sa_vm.svm_family = AF_VSOCK;
-    sa_vm.svm_cid = VMADDR_CID_HOST;
-    sa_vm.svm_port = 1024;
+    sa_vm.svm_cid = cid;
+    sa_vm.svm_port = vsockPort;
 
     if (connect(sockfd, (struct sockaddr*)&sa_vm, sizeof(struct sockaddr_vm)) < 0) {
         perror("Failed to connect");


### PR DESCRIPTION
EXAMPLES:

```shell
$ ./vsock_guest_exec 1:2049 # cid is 2, vsock port is 2049
$ ./vsock_guest_exec -1: # cid set to -1 (VMADDR_CID_ANY), vsock port is
default(1024)
$ ./vsock_guest_exec :1025 # vsock port set to 1025, cid is default(2)

$ ./vsock_guest_exec foo:bar # cid is default(2), vsock port is default(1024)
```